### PR TITLE
Added error handling behavior to Explorer.

### DIFF
--- a/app/components/aggregate-query-maker.js
+++ b/app/components/aggregate-query-maker.js
@@ -19,16 +19,7 @@ export default Ember.Component.extend({
     }
   },
 
-  //IDs for cities, their locations and zoom.
-  cities: {
-    "chicago": {label: "Chicago", location: [41.795509, -87.581916], zoom: 10},
-    "newyork": {label: "New York", location:[40.7268362,-74.0017699], zoom: 10},
-    "seattle": {label: "Seattle", location:[47.6076397,-122.3258644], zoom: 11},
-    "sanfrancisco": {label: "San Francisco", location:[37.7618864,-122.4406926], zoom: 12},
-    "austin": {label: "Austin", location:[30.3075693,-97.7399898], zoom: 10},
-    "denver": {label: "Denver", location:[39.7534338,-104.890141], zoom: 11},
-    "bristol": {label: "Bristol, UK", location:[51.4590572,-2.5909956], zoom: 11}
-  },
+  cities: {},
 
   //IDs to populate the dropdown box. Computed from the cities dict above.
   citiesList: Ember.computed('cities', function(){

--- a/app/components/aggregate-query-maker.js
+++ b/app/components/aggregate-query-maker.js
@@ -1,13 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  notify: Ember.inject.service('notify'),
 
   init() {
     this._super(...arguments);
-    const teleportState = Ember.Object.create({
-      center: this.get("center")
-    });
-    this.set('teleportState', teleportState);
     if(this.get('center'))
     {
       if(this.get('center') in this.get('cities'))
@@ -15,8 +12,12 @@ export default Ember.Component.extend({
         //Translate an initial location to coordinates
         //'centerCoords' is the raw-coordinates form of the human-readable 'center'
         this.set('centerCoords', [this.get(`cities.${this.get('center')}.location`), this.get(`cities.${this.get('center')}.zoom`)]);
+      } else {
+        this.get('notify').warning(`Unknown city "${this.get('center')}". Try selecting a city from the "Center map on" menu.`);
+        this.set('center', 'chicago');
       }
     }
+    this.set('teleportState', {center: this.get('center')});
   },
 
   cities: {},
@@ -41,7 +42,9 @@ export default Ember.Component.extend({
   changedCenter: Ember.observer('teleportState.center', function() {
     const city = this.get('teleportState.center');
     this.set('center', this.get('teleportState.center'));
-    this.set('centerCoords', [this.get(`cities.${city}.location`), this.get(`cities.${city}.zoom`)]);
+    if(city in this.get('cities')) {
+      this.set('centerCoords', [this.get(`cities.${city}.location`), this.get(`cities.${city}.zoom`)]);
+    }
   }),
 
   actions: {

--- a/app/components/drop-downs.js
+++ b/app/components/drop-downs.js
@@ -12,28 +12,15 @@ export default Ember.Component.extend({
     this.set('optionState', optionState);
   },
 
-  aggOptions: ([
-    {id: 'day', label: 'day'},
-    {id: 'week', label: 'week'},
-    {id: 'month', label: 'month'},
-    {id: 'quarter', label: 'quarter'},
-    {id: 'year', label: 'year'}
-  ]),
+  aggOptions: [],
 
-  resOptions: ([
-    {id: '100', label: '100 meters'},
-    {id: '200', label: '200 meters'},
-    {id: '300', label: '300 meters'},
-    {id: '400', label: '400 meters'},
-    {id: '500', label: '500 meters'},
-    {id: '1000', label: '1 kilometer'}
-  ]),
+  resoptions: [],
 
   didUpdateAttrs() {
     this.set('optionState.agg', this.get('agg'));
     this.set('optionState.res', this.get('res'));
   },
-  
+
   changedAgg: Ember.observer('optionState.agg', function() {
     const newAgg = this.get('optionState.agg');
     this.set('agg', newAgg);

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -33,6 +33,38 @@ export default Ember.Controller.extend({
     return Ember.copy(this.get('queryParamsHash'));
   },
 
+  //Central location to define all acceptable values for aggregate-query-maker
+  //IDs for cities, their locations and zoom.
+  
+  cities: {
+    "chicago": {label: "Chicago", location: [41.795509, -87.581916], zoom: 10},
+    "newyork": {label: "New York", location:[40.7268362,-74.0017699], zoom: 10},
+    "seattle": {label: "Seattle", location:[47.6076397,-122.3258644], zoom: 11},
+    "sanfrancisco": {label: "San Francisco", location:[37.7618864,-122.4406926], zoom: 12},
+    "austin": {label: "Austin", location:[30.3075693,-97.7399898], zoom: 10},
+    "denver": {label: "Denver", location:[39.7534338,-104.890141], zoom: 11},
+    "bristol": {label: "Bristol, UK", location:[51.4590572,-2.5909956], zoom: 11}
+  },
+
+  aggOptions: ([
+    {id: 'day', label: 'day'},
+    {id: 'week', label: 'week'},
+    {id: 'month', label: 'month'},
+    {id: 'quarter', label: 'quarter'},
+    {id: 'year', label: 'year'}
+  ]),
+
+  resOptions: ([
+    {id: '100', label: '100 meters'},
+    {id: '200', label: '200 meters'},
+    {id: '300', label: '300 meters'},
+    {id: '400', label: '400 meters'},
+    {id: '500', label: '500 meters'},
+    {id: '1000', label: '1 kilometer'}
+  ]),
+
+  //------------- end of central aggregate-query-maker values ---------------//
+
   _zoomIn() {
     this.set('zoom', true);
     const self = this;

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -35,7 +35,7 @@ export default Ember.Controller.extend({
 
   //Central location to define all acceptable values for aggregate-query-maker
   //IDs for cities, their locations and zoom.
-  
+
   cities: {
     "chicago": {label: "Chicago", location: [41.795509, -87.581916], zoom: 10},
     "newyork": {label: "New York", location:[40.7268362,-74.0017699], zoom: 10},

--- a/app/controllers/discover/aggregate.js
+++ b/app/controllers/discover/aggregate.js
@@ -68,7 +68,7 @@ export default Ember.Controller.extend({
       discoverAggregateController.get('notify').error(`A problem occurred while processing your request: ${message}`);
       tipsMachine(message);
       discoverAggregateController.transitionToRoute('discover');
-    }
+    };
 
     let tipsMachine = function(message){
       if(message.toLowerCase().indexOf("empty")>-1 || message.toLowerCase().indexOf("format")>-1) {
@@ -76,9 +76,9 @@ export default Ember.Controller.extend({
       } else {
         discoverAggregateController.get('notify').info('Try resetting your query and starting over.');
       }
-    }
+    };
 
-    if(this.get('model').pointDatasets) {
+    if(this.get('model').pointDatasets.error) {
       queryError(this.get('model').pointDatasets.error.message);
       return;
     }

--- a/app/controllers/discover/aggregate.js
+++ b/app/controllers/discover/aggregate.js
@@ -74,11 +74,11 @@ export default Ember.Controller.extend({
             eligible--;
           if (!alreadyErrored) {
             discoverAggregateController.set('searchingDatasets', false);
-            discoverAggregateController.get('notify').error(`A problem occurred while processing your request: ${value.error.message}`)
+            discoverAggregateController.get('notify').error(`A problem occurred while processing your request: ${value.error.message}`);
             if (value.error.message.indexOf('format') > -1) {
-              discoverAggregateController.get('notify').info('Maybe try resetting your query?')
+              discoverAggregateController.get('notify').info('Maybe try resetting your query?');
             }
-            discoverAggregateController.transitionToRoute('discover')
+            discoverAggregateController.transitionToRoute('discover');
             alreadyErrored = true;
           }
           return;

--- a/app/controllers/event.js
+++ b/app/controllers/event.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 export default Ember.Controller.extend({
   query: Ember.inject.service(),
   notify: Ember.inject.service(),
+  discoverController: Ember.inject.controller('discover'),
 
   queryParams: ['filters', 'agg', 'resolution',
                 'obs_date__le', 'obs_date__ge', 'location_geom__within'],
@@ -32,6 +33,15 @@ export default Ember.Controller.extend({
   queryParamsClone() {
     return Ember.copy(this.get('queryParamsHash'));
   },
+
+  //These centralized options are stored in the discover root controller
+  aggOptions: Ember.computed('discoverController', function() {
+    return this.get('discoverController').get('aggOptions');
+  }),
+
+  resOptions: Ember.computed('discoverController', function() {
+    return this.get('discoverController').get('resOptions');
+  }),
 
   /*
    The model we get from the route is just

--- a/app/router.js
+++ b/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   });
   this.route('event', {path: '/event/:dataset_name'});
   this.route('shape', {path: '/shape/:dataset_name'});
+  this.route('not-found', {path: '/*:path_name'});
   this.route('loading');
 });
 

--- a/app/routes/discover/aggregate.js
+++ b/app/routes/discover/aggregate.js
@@ -29,6 +29,8 @@ export default Ember.Route.extend({
       self.get('notify').error(message);
     };
 
+    //*** VALIDATION STEPS: Logic here validates the query parameters before submitting the query. ***//
+
     // Check that location_geom__within is a valid polygon or line segment
     const genericHelp = 'Please draw a shape on the map before submitting.';
 
@@ -40,6 +42,7 @@ export default Ember.Route.extend({
     }
     catch (err) {
       bailToIndex('Invalid JSON. ' + genericHelp);
+      self.get('notify').info("Maybe try resetting your query?");
     }
 
     if (!GJV.isFeature(geoJSON)) {
@@ -50,6 +53,13 @@ export default Ember.Route.extend({
     if (!isPolygonOrLine) {
       bailToIndex('Geometry must be a polygon or line. ' + genericHelp);
     }
+
+    //Ensure that start date >= end date
+    if(new Date(params.obs_date__le) < new Date(params.obs_date__ge)){
+      bailToIndex('Problem while interpreting query: Start date should be before End date.')
+    }
+
+    //*** END VALIDATION STEPS ***//
 
     //Start a spinner cue (whose toggle lives in controllers/discover.js,
     //and whose DOM lives in templates/discover.hbs)

--- a/app/routes/discover/aggregate.js
+++ b/app/routes/discover/aggregate.js
@@ -56,7 +56,7 @@ export default Ember.Route.extend({
 
     //Ensure that start date >= end date
     if(new Date(params.obs_date__le) < new Date(params.obs_date__ge)){
-      bailToIndex('Problem while interpreting query: Start date should be before End date.')
+      bailToIndex('Problem while interpreting query: Start date should be before End date.');
     }
 
     //*** END VALIDATION STEPS ***//

--- a/app/routes/discover/aggregate.js
+++ b/app/routes/discover/aggregate.js
@@ -55,17 +55,17 @@ export default Ember.Route.extend({
     }
 
     //Check if the selected agg parameter is valid
-    if($.grep(this.controllerFor('discover').get('aggOptions'), function(e){ return e.label == params.agg; }).length == 0)
+    if($.grep(this.controllerFor('discover').get('aggOptions'), function(e){ return e.label === params.agg; }).length === 0)
     {
       bailToIndex('Unknown value for "agg". Try selecting a valid option from the "Aggregate by" dropdown.');
     }
-    
+
     //Ensure that start date >= end date
     if(new Date(params.obs_date__le) < new Date(params.obs_date__ge)){
       bailToIndex('Query error: Start date should be before End date.');
     }
 
-    
+
 
     //*** END VALIDATION STEPS ***//
 

--- a/app/routes/discover/aggregate.js
+++ b/app/routes/discover/aggregate.js
@@ -60,12 +60,21 @@ export default Ember.Route.extend({
       bailToIndex('Unknown value for "agg". Try selecting a valid option from the "Aggregate by" dropdown.');
     }
 
+    //Ensure that obs_date__le and obs_date__ge are valid date objects.
+    if(isNaN((new Date(params.obs_date__ge)).getTime()))
+    {
+      bailToIndex('"obs_date__ge" does not specify a valid date. Please check this query parameter, or set a valid date using the "Start date" selector.');
+    }
+
+    if(isNaN((new Date(params.obs_date__le)).getTime()))
+    {
+      bailToIndex('"obs_date__le" does not specify a valid date. Please check this query parameter, or set a valid date using the "End date" selector.');
+    }
+
     //Ensure that start date >= end date
     if(new Date(params.obs_date__le) < new Date(params.obs_date__ge)){
       bailToIndex('Query error: Start date should be before End date.');
     }
-
-
 
     //*** END VALIDATION STEPS ***//
 

--- a/app/routes/discover/aggregate.js
+++ b/app/routes/discover/aggregate.js
@@ -54,10 +54,18 @@ export default Ember.Route.extend({
       bailToIndex('Geometry must be a polygon or line. ' + genericHelp);
     }
 
+    //Check if the selected agg parameter is valid
+    if($.grep(this.controllerFor('discover').get('aggOptions'), function(e){ return e.label == params.agg; }).length == 0)
+    {
+      bailToIndex('Unknown value for "agg". Try selecting a valid option from the "Aggregate by" dropdown.');
+    }
+    
     //Ensure that start date >= end date
     if(new Date(params.obs_date__le) < new Date(params.obs_date__ge)){
-      bailToIndex('Problem while interpreting query: Start date should be before End date.');
+      bailToIndex('Query error: Start date should be before End date.');
     }
+
+    
 
     //*** END VALIDATION STEPS ***//
 

--- a/app/routes/not-found.js
+++ b/app/routes/not-found.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  afterModel(){
+    Ember.run.later(this, function(){
+      this.transitionTo('index');
+    }, 1000);
+  }
+});

--- a/app/services/query.js
+++ b/app/services/query.js
@@ -142,6 +142,7 @@ export default Ember.Service.extend({
         };
       }, function(reason) {
         console.log(reason);
+        return { error: reason };
       });
     }
   },

--- a/app/services/query.js
+++ b/app/services/query.js
@@ -236,6 +236,7 @@ export default Ember.Service.extend({
       });
     }, function(reason) {
       console.log(`Event candidate query failed: ${reason}`);
+      return {error: reason};
     });
   },
 
@@ -252,6 +253,7 @@ export default Ember.Service.extend({
       });
     }, function(reason) {
       console.log(`Shape subset query failed: ${reason}`);
+      return {error: reason};
     });
   },
 

--- a/app/templates/components/aggregate-query-maker.hbs
+++ b/app/templates/components/aggregate-query-maker.hbs
@@ -23,7 +23,7 @@
       </div>
 
       {{date-range startDate=startDate endDate=endDate override=override}}
-      {{drop-downs agg=agg}}
+      {{drop-downs agg=agg aggOptions=aggOptions}}
       {{submit-or-reset submit=(action submit) reset=(action reset)}}
       <div style="margin-bottom: 10px"></div>
       {{#em-form

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -1,4 +1,7 @@
 {{aggregate-query-maker
+cities=cities
+aggOptions=aggOptions
+resOptions=resOptions
 startDate=obs_date__ge
 endDate=obs_date__le
 geoJSON=location_geom__within

--- a/app/templates/event.hbs
+++ b/app/templates/event.hbs
@@ -7,7 +7,7 @@
       {{model.attribution}}: {{model.humanName}}
   </h3>
     {{date-range startDate=obs_date__ge endDate=obs_date__le}}
-    {{drop-downs agg=agg res=resolution}}
+    {{drop-downs agg=agg res=resolution aggOptions=aggOptions resOptions=resOptions}}
     {{column-filters filters=filters metadata=model}}
     <br/>
 

--- a/app/templates/not-found.hbs
+++ b/app/templates/not-found.hbs
@@ -1,0 +1,7 @@
+<div class="row" style="text-align: center; margin-top: 10%">
+  <div class="col-md-12">
+    <h1>Resource Not Found</h1>
+    <p>Going back to Plenar.io Explore</p>
+  </div>
+</div>
+{{spin-spinner lines=13 length=20 width=10}}

--- a/tests/unit/routes/not-found-test.js
+++ b/tests/unit/routes/not-found-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:not-found', 'Unit | Route | not found', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
This PR brings some new error handling features to Plenario Explorer which move the user to known states and suggest ways to resolve the error.

Specific changes include:
- New 404-esque page which redirects users back to the "index" route after a short delay and a "Resource Not Found" message.
- Extra validation steps upon entering /discover/aggregate, specifically
  - Checking that "agg" is a valid value;
  - Checking that start and end dates are valid; and
  - Checking that start date is before end date.
- Error handling in the query service, particularly when the query for candidates or timeseries returns an error. Also added checks in /discover/aggregate to catch these errors and produce interpreted error messages and redirect the user back to /discover.
- Specified default behavior for the map centering feature in aggregate-query-maker. Unknown city names in the "center" query parameter are now ignored, and center is set to "chicago" as a default. The user is also notified with a warning.

In order to assist with validation, the valid options for aggOptions, resOptions, and cities have been centralized in the main discover controller, making them accessible throughout the app (and also making them easier to update as more options become available). These used to be separate in their respective components.
