### PR TITLE
Added Dataset Table Preview to /events Pages

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -25,6 +25,13 @@ export default App;
 
 Ember.onerror = function (error) {
   console.log('GLOBAL ERROR:', error.message);
-  window.location = `/error/${error.message}`;  //TODO: Quick and dirty redirect...
-                                                //TODO: Need to figure out how to transition to route from here.
+  //Not all errors are really serious enough to
+  //suddenly take the user out of the flow.
+  //So we whitelist error keywords here.
+  if (error.message.toLowerCase().indexOf('fatal') > -1 ||
+    error.message.toLowerCase().indexOf('malformed') > -1) {
+    window.location = `/error/${error.message}`;
+  }
+  //TODO: Quick and dirty redirect...
+  //TODO: Need to figure out how to transition to route from here.
 };

--- a/app/components/aggregate-query-maker.js
+++ b/app/components/aggregate-query-maker.js
@@ -16,7 +16,6 @@ export default Ember.Component.extend({
         let splits = this.get('center').split(',');
         this.set('centerCoords', [[parseFloat(splits[0]), parseFloat(splits[1])], parseFloat(splits[2])]);
       } else {
-        console.log(this.get('center'));
         this.get('notify').warning(`Unknown city "${this.get('center')}". Try selecting a city from the "Center map on" menu.`);
         this.set('center', 'chicago');
       }
@@ -62,11 +61,10 @@ export default Ember.Component.extend({
     },
     mapMovedByUser(newcenter){
       let self = this;
-      if(!(this.get('center') in this.get('cities') && this.get('centerCoords') === newcenter)) {
-        Ember.run.next(function () {
-          self.set('center', newcenter);
-        });
-      }
+      Ember.run.next(function () {
+        if (self.isDestroyed) { return; } //Workaround to fix testing
+        self.set('center', newcenter);
+      });
     }
   },
 

--- a/app/components/aggregate-query-maker.js
+++ b/app/components/aggregate-query-maker.js
@@ -12,7 +12,11 @@ export default Ember.Component.extend({
         //Translate an initial location to coordinates
         //'centerCoords' is the raw-coordinates form of the human-readable 'center'
         this.set('centerCoords', [this.get(`cities.${this.get('center')}.location`), this.get(`cities.${this.get('center')}.zoom`)]);
+      } else if (this.get('center').split(',').length === 3) {
+        let splits = this.get('center').split(',');
+        this.set('centerCoords', [[parseFloat(splits[0]), parseFloat(splits[1])], parseFloat(splits[2])]);
       } else {
+        console.log(this.get('center'));
         this.get('notify').warning(`Unknown city "${this.get('center')}". Try selecting a city from the "Center map on" menu.`);
         this.set('center', 'chicago');
       }
@@ -56,6 +60,14 @@ export default Ember.Component.extend({
     dismissIntro(){
       $("#collapse-intro").collapse("hide");
     },
+    mapMovedByUser(newcenter){
+      let self = this;
+      if(!(this.get('center') in this.get('cities') && this.get('centerCoords') === newcenter)) {
+        Ember.run.next(function () {
+          self.set('center', newcenter);
+        });
+      }
+    }
   },
 
 });

--- a/app/components/data-table.js
+++ b/app/components/data-table.js
@@ -6,5 +6,23 @@ export default Ember.Component.extend({
     this._super(...arguments);
     this.set('columns', Object.keys(this.get('events')[0]));
     this.set('columnNames', Object.keys(this.get('events')[0]).map(v => humanizeName(v)));
+  },
+
+  showTable: false,
+
+  actions: {
+
+    showDatasetPreview() {
+      this.set('showTable', true);
+      console.log($('#container').outerHeight(true));
+      $('#container-container').animate({height: $('#container').outerHeight(true)}, 500);
+      $('html,body').animate({scrollTop: $(document).height()}, 500);
+
+    },
+    hideDatasetPreview() {
+      this.set('showTable', false);
+      $('#container-container').animate({height: '0vh'}, 500);
+    },
+
   }
 });

--- a/app/components/data-table.js
+++ b/app/components/data-table.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import humanizeName from '../utils/humanize-name';
+
+export default Ember.Component.extend({
+  init(){
+    this._super(...arguments);
+    this.set('columnNames', this.get('columns').map(v => humanizeName(v)));
+  }
+});

--- a/app/components/data-table.js
+++ b/app/components/data-table.js
@@ -4,6 +4,7 @@ import humanizeName from '../utils/humanize-name';
 export default Ember.Component.extend({
   init(){
     this._super(...arguments);
-    this.set('columnNames', this.get('columns').map(v => humanizeName(v)));
+    this.set('columns', Object.keys(this.get('events')[0]));
+    this.set('columnNames', Object.keys(this.get('events')[0]).map(v => humanizeName(v)));
   }
 });

--- a/app/components/leaflet-map.js
+++ b/app/components/leaflet-map.js
@@ -29,6 +29,11 @@ export default Ember.Component.extend({
       this.addTiles();
       this.drawElements();
       this.createLegend();
+
+      let self = this;
+      this.map.on('moveend', function(){ //Setup listener that signals the parent component when the map changes.
+        self.updateCenter(self);
+      });
     });
   },
 
@@ -213,5 +218,13 @@ export default Ember.Component.extend({
   changedCenter: Ember.observer('center', function() {
     this.get('map').setView(new L.LatLng(...this.get('center')[0]), this.get('center')[1]);
   }),
+
+  //Scope here seems a bit different, eh?
+  //It's because it's bound to a map event ('moveend') way up in didInsertElement
+  updateCenter(self) {
+    if(!(self.map.getCenter().lat === this.get('center')[0][0] && self.map.getCenter().lng === this.get('center')[0][1] && self.map.getZoom() === this.get('center')[1])) {
+      self.sendAction('mapMovedByUser', [[self.map.getCenter().lat, self.map.getCenter().lng], self.map.getZoom()]);
+    }
+  },
 
 });

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -37,6 +37,7 @@ export default Ember.Controller.extend({
   //IDs for cities, their locations and zoom.
 
   cities: {
+    "00default": {label: "Select a city to teleport to it.", location: [41.795509, -87.581916], zoom: 10},
     "chicago": {label: "Chicago", location: [41.795509, -87.581916], zoom: 10},
     "newyork": {label: "New York", location:[40.7268362,-74.0017699], zoom: 10},
     "seattle": {label: "Seattle", location:[47.6076397,-122.3258644], zoom: 11},

--- a/app/controllers/event.js
+++ b/app/controllers/event.js
@@ -53,7 +53,7 @@ export default Ember.Controller.extend({
     this.set('loading', true);
     this.adjustDateRange();
     this.launchWidgetQueries();
-    this.set('columns', this.get('model.columns').map(v => v.field_name))
+    this.set('columns', this.get('model.columns').map(v => v.field_name));
   }),
 
   resetParams() {

--- a/app/controllers/event.js
+++ b/app/controllers/event.js
@@ -53,6 +53,7 @@ export default Ember.Controller.extend({
     this.set('loading', true);
     this.adjustDateRange();
     this.launchWidgetQueries();
+    this.set('columns', this.get('model.columns').map(v => v.field_name))
   }),
 
   resetParams() {
@@ -79,7 +80,8 @@ export default Ember.Controller.extend({
 
     Ember.RSVP.hash({
       timeseries: qService.timeseries(qParams),
-      grid: qService.grid(qParams)
+      grid: qService.grid(qParams),
+      events: qService.rawEvents(qParams)
     }).then(result => {
       if (result.grid === undefined || result.timeseries === undefined) {
         if (shouldRetry) {
@@ -95,6 +97,7 @@ export default Ember.Controller.extend({
       }
       this.set('timeseries', result.timeseries);
       this.set('grid', result.grid);
+      this.set('events', result.events.objects);
       this.set('loading', false);
     });
   },

--- a/app/controllers/event.js
+++ b/app/controllers/event.js
@@ -53,7 +53,6 @@ export default Ember.Controller.extend({
     this.set('loading', true);
     this.adjustDateRange();
     this.launchWidgetQueries();
-    this.set('columns', this.get('model.columns').map(v => v.field_name));
   }),
 
   resetParams() {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -340,6 +340,7 @@ a
   position: relative;
   width: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
 }
 .data-table-container
 {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -323,3 +323,66 @@ h3 {
   margin-bottom: 10px;
   line-height: 1.2em;
 }
+
+/* data-table component */
+.data-table-container-container
+{
+  position: relative;
+  width: 100%;
+  overflow-x: auto;
+}
+.data-table-container
+{
+  margin-top: 3.5em;
+  height: 40vh;
+  display: inline-block;
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-width: 100%;
+}
+
+.data-table
+{
+  table-layout: fixed;
+  overflow: hidden;
+}
+
+.data-table td, .data-table th, .data-table th div
+{
+  width: 200px;
+  padding: 10px;
+  word-wrap: break-word;
+  overflow: hidden;
+}
+
+.data-table th div
+{
+  position: absolute;
+  top: 0;
+}
+
+.data-table thead
+{
+  height: 0;
+}
+
+.data-table th span
+{
+  display: block;
+  height: 0;
+  color: transparent;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+a
+{
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  /* This is the dangerous one in WebKit, as it breaks things wherever */
+  word-break: break-all;
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -333,48 +333,38 @@ h3 {
 }
 .data-table-container
 {
-  margin-top: 3.5em;
-  height: 40vh;
+  margin-top: 1.5em;
+  height: 50vh;
   display: inline-block;
   overflow-x: hidden;
   overflow-y: auto;
   min-width: 100%;
+  border: 1px solid darkgray;
 }
 
 .data-table
 {
-  table-layout: fixed;
   overflow: hidden;
+  background: white;
 }
 
-.data-table td, .data-table th, .data-table th div
+.data-table th .sticky
 {
-  width: 200px;
-  padding: 10px;
-  word-wrap: break-word;
-  overflow: hidden;
-}
-
-.data-table th div
-{
+  display: block;
+  white-space: nowrap;
   position: absolute;
   top: 0;
 }
 
-.data-table thead
+.data-table th .reference
 {
-  height: 0;
-}
-
-.data-table th span
-{
-  display: block;
   height: 0;
   color: transparent;
   -moz-user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 a

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -324,6 +324,16 @@ h3 {
   line-height: 1.2em;
 }
 
+a
+{
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  /* This is the dangerous one in WebKit, as it breaks things wherever */
+  word-break: break-all;
+}
+
 /* data-table component */
 .data-table-container-container
 {
@@ -367,12 +377,7 @@ h3 {
   white-space: nowrap;
 }
 
-a
+.data-table thead
 {
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-
-  -ms-word-break: break-all;
-  /* This is the dangerous one in WebKit, as it breaks things wherever */
-  word-break: break-all;
+  background: dimgray;
 }

--- a/app/templates/components/aggregate-query-maker.hbs
+++ b/app/templates/components/aggregate-query-maker.hbs
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="col-md-7 half-height">
-      {{leaflet-map center=centerCoords geoJSON=geoJSON isDrawable=true zoom=zoom}}
+      {{leaflet-map center=centerCoords mapMovedByUser=(action 'mapMovedByUser') geoJSON=geoJSON isDrawable=true zoom=zoom}}
     </div>
   </div>
 

--- a/app/templates/components/data-table.hbs
+++ b/app/templates/components/data-table.hbs
@@ -15,6 +15,7 @@
               <td>{{get row column}}</td>
             {{/each}}
           </tr>
+          <tr></tr>
         {{/each}}
       </tbody>
     </table>

--- a/app/templates/components/data-table.hbs
+++ b/app/templates/components/data-table.hbs
@@ -1,5 +1,5 @@
-<div class="data-table-container-container">
-  <div class="data-table-container">
+<div id="container-container" class="data-table-container-container" style="height: 0vh">
+  <div id="container" class="data-table-container">
     <table class="data-table table table-bordered table-hover">
       <thead>
         <tr>
@@ -21,3 +21,8 @@
     </table>
   </div>
 </div>
+{{#if showTable}}
+  <div style="width: 100%; text-align: center; margin-top: 12px;"><button style="display: inline-block" type="button" class="btn btn-info" {{action 'hideDatasetPreview'}}>Hide Dataset Preview</button></div>
+{{else}}
+  <div style="width: 100%; text-align: center; margin-top: 12px;"><button style="display: inline-block" type="button" class="btn btn-info" {{action 'showDatasetPreview'}}>Show Dataset Preview</button></div>
+{{/if}}

--- a/app/templates/components/data-table.hbs
+++ b/app/templates/components/data-table.hbs
@@ -1,0 +1,22 @@
+<div class="data-table-container-container">
+  <div class="data-table-container">
+    <table class="data-table table table-hover">
+      <thead>
+        <tr>
+            {{#each columnNames as |name|}}
+              <th><div class="data-table-sticky-header">{{name}}</div><span>{{name}}</span></th>
+            {{/each}}
+        </tr>
+      </thead>
+      <tbody>
+        {{#each events as |row|}}
+          <tr>
+            {{#each columns as |column|}}
+              <td>{{get row column}}</td>
+            {{/each}}
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/templates/components/data-table.hbs
+++ b/app/templates/components/data-table.hbs
@@ -1,10 +1,10 @@
 <div class="data-table-container-container">
   <div class="data-table-container">
-    <table class="data-table table table-hover">
+    <table class="data-table table table-bordered table-hover">
       <thead>
         <tr>
             {{#each columnNames as |name|}}
-              <th><div class="data-table-sticky-header">{{name}}</div><span>{{name}}</span></th>
+              <th><div class="sticky">{{name}}</div><div class="reference">{{name}}</div></th>
             {{/each}}
         </tr>
       </thead>

--- a/app/templates/event.hbs
+++ b/app/templates/event.hbs
@@ -56,10 +56,7 @@
         {{widget-spin}}
           <div style="height: 40vh"></div>
       {{else}}
-        {{data-table
-        events=events
-        columns=columns
-        }}
+        {{data-table events=events}}
       {{/if}}
     </div>
 </div>

--- a/app/templates/event.hbs
+++ b/app/templates/event.hbs
@@ -32,14 +32,6 @@
         </ul>
       </div>
     </div>
-    <hr />
-    <h4>API queries</h4>
-    <p>View the API queries that are used on this page. <a href='/api-docs/'>Read the API docs</a>.</p>
-    <ul class=''>
-        <li><a {{action "download" "grid"}}><code>/v1/api/grid/&hellip;</code></a></li>
-        <li><a {{action "download" "timeseries"}}><code>/v1/api/detail-aggregate/&hellip;</code></a></li>
-        <li><a {{action "download" "geoJSONPoints"}}><code>/v1/api/detail/&hellip;</code></a></li>
-    </ul>
   </div>
   <div class="col-md-7">
       {{#if loading}}
@@ -53,10 +45,37 @@
           </h3>
         {{heat-grid grid=grid datasetName=model.humanName}}
         {{high-charts classNames=chartClasses content=timeseries.series}}
-        <hr />
-        <h4>Dataset details</h4>
-        {{metadata-display m=model}}
       {{/if}}
-
   </div>
+</div>
+<div class="row rowbox">
+    <hr />
+    <div class="col-md-12">
+      <h3 class='detail-header'>Dataset Preview <i>{{#if loading}}(loading...){{else}}({{events.length}} entries loaded){{/if}}</i></h3>
+      {{#if loading}}
+        {{widget-spin}}
+          <div style="height: 40vh"></div>
+      {{else}}
+        {{data-table
+        events=events
+        columns=columns
+        }}
+      {{/if}}
+    </div>
+</div>
+<div class="row rowbox">
+    <hr />
+    <div class="col-md-5">
+        <h4>API queries</h4>
+        <p>View the API queries that are used on this page. <a href='/api-docs/'>Read the API docs</a>.</p>
+        <ul class=''>
+            <li><a {{action "download" "grid"}}><code>/v1/api/grid/&hellip;</code></a></li>
+            <li><a {{action "download" "timeseries"}}><code>/v1/api/detail-aggregate/&hellip;</code></a></li>
+            <li><a {{action "download" "geoJSONPoints"}}><code>/v1/api/detail/&hellip;</code></a></li>
+        </ul>
+    </div>
+    <div class="col-md-7">
+      <h4>Dataset details</h4>
+      {{metadata-display m=model}}
+    </div>
 </div>

--- a/tests/acceptance/error-handling-test.js
+++ b/tests/acceptance/error-handling-test.js
@@ -32,7 +32,9 @@ test('Using an invalid agg option will return to index and issue an error.', fun
     visit('/discover?agg=ksdfasdkh&location_geom__within=' + geoJSON);
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
     });
   });
 });
@@ -44,7 +46,9 @@ test('Attempting to query with startDate after endDate returns to index and issu
     visit('/discover?obs_date__ge=2016-06-18&obs_date__le=2016-06-12&location_geom__within=' + geoJSON);
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
     });
   });
 });
@@ -57,14 +61,18 @@ test('Attempting to query with invalid startDate and endDate returns to index an
     visit('/discover?obs_date__ge=20asdkgasdj8&obs_date__le=2016-06-12&location_geom__within=' + geoJSON);
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
-      visit('/discover/aggregate?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
       andThen(function () {
-        assert.equal(currentRouteName(), 'discover.index', 'The page returns to index. (obs_date__le)');
-        visit('/discover?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+        visit('/discover/aggregate?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
         andThen(function () {
-          $('#submit-query').click();
-          assert.notEqual($('.message').text(), "", "The page issued an error.");
+          assert.equal(currentRouteName(), 'discover.index', 'The page returns to index. (obs_date__le)');
+          visit('/discover?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
+          andThen(function () {
+            $('#submit-query').click();
+            andThen(function () {
+              assert.notEqual($('.message').text(), "", "The page issued an error.");
+            });
+          });
         });
       });
     });
@@ -79,7 +87,9 @@ test('Attempting to query with invalid JSON returns to index and issues an error
     visit('/discover?location_geom__within=%7B%22type%22%3A%22Feature%22%3A%7B%7D%2C%22geometry%22%3A%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-87.80672550201416%2C41.74262728637672%5D%2C%5B-87.80672550201416%2C41.97582726102573%5D%2C%5B-87.45653629302979%2C41.97582726102573%5D%2C%5B-87.45653629302979%2C41.74262728637672%5D%2C%5B-87.80672550201416%2C41.74262728637672%5D%5D%5D%7D%7D');
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
     });
   });
 });
@@ -89,8 +99,12 @@ test('Attempting to query without a geoJSON returns to index and issues an error
   andThen(function () {
     assert.equal(currentRouteName(), 'discover.index', 'The page returns to index.');
     visit('/discover');
+    andThen(function(){
     $('#submit-query').click();
-    assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
+    });
   });
 });
 

--- a/tests/acceptance/user-query-test.js
+++ b/tests/acceptance/user-query-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import {test} from 'qunit';
 import moduleForAcceptance from 'plenario-explorer/tests/helpers/module-for-acceptance';
 import testData from 'plenario-explorer/mirage/test-data';
@@ -55,12 +56,16 @@ test('User can reset a query.', function (assert) {
   visit('/discover/aggregate?location_geom__within=' + geoJSON + '&obs_date__ge=2010-06-10&obs_date__le=2017-07-02');
   andThen(function () {
     assert.equal($('#point-aggregate-listing').is('div'), true);
-    click('#reset-query');
-    andThen(function () {
-      assert.equal(currentURL(), '/discover', "Resetting the route returns to /discover.");
-      assert.equal($('#point-aggregate-listing').is('div'), false, "Resetting the route succeeded; point aggregate listing is no longer present.");
-      assert.equal($('#point-index-listing').is('div'), true, "Resetting the route succeeded; point index listing is now present.");
-    });
+    return Ember.run.later(function(){ //Wait for everything to stop moving
+      click('#reset-query');
+      andThen(function () {
+        return Ember.run.later(function(){
+          assert.equal(currentURL(), '/discover', "Resetting the route returns to /discover.");
+          assert.equal($('#point-aggregate-listing').is('div'), false, "Resetting the route succeeded; point aggregate listing is no longer present.");
+          assert.equal($('#point-index-listing').is('div'), true, "Resetting the route succeeded; point index listing is now present.");
+        });
+      });
+    }, 10);
   });
 });
 
@@ -89,6 +94,14 @@ test('Changing the map center selection changes the actual map.', function (asse
         });
       });
     });
+  });
+});
+
+
+test('User can directly specify a map center coordinates via the URL.', function(assert){
+  visit('/discover?center=51.89426503878691,1.4826178550720215,15');
+  andThen(function(){
+    assert.notEqual($('#map').find('img[src$="/15/16518/10839.png"]').length, 0, "Map uses coordinates to center on Sealand.");  //Sealand map tile
   });
 });
 

--- a/tests/acceptance/user-query-test.js
+++ b/tests/acceptance/user-query-test.js
@@ -65,7 +65,7 @@ test('User can reset a query.', function (assert) {
           assert.equal($('#point-index-listing').is('div'), true, "Resetting the route succeeded; point index listing is now present.");
         });
       });
-    }, 10);
+    }, 1000);
   });
 });
 

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('data-table', 'Integration | Component | data table', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{data-table}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#data-table}}
+      template block text
+    {{/data-table}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -9,16 +9,9 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{data-table}}`);
+  this.set('columns', ['a', 'b', 'c']);
+  this.render(hbs`{{data-table columns=columns}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.notEqual(this.$().text().trim(), '');
 
-  // Template block usage:
-  this.render(hbs`
-    {{#data-table}}
-      template block text
-    {{/data-table}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -9,8 +9,8 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.set('columns', ['a', 'b', 'c']);
-  this.render(hbs`{{data-table columns=columns}}`);
+  this.set('events', [{"a": "b"}]);
+  this.render(hbs`{{data-table events=events}}`);
 
   assert.notEqual(this.$().text().trim(), '');
 


### PR DESCRIPTION
As per a [feature request filed under the main Plenar.io repo](https://github.com/UrbanCCD-UChicago/plenario/issues/203), here is a new dataset table preview that loads sample rows from the dataset via the query service. This gets rows through an additional `rawEvents` query done at the same time as the existing `timeseries` and `grid` queries.

There doesn't seem to be a good way to ask the Plenar.io API for fewer than 1000 events thus far, and so the `rawEvents` will retrieve the first 1000 available; this doesn't increase load times _too_ much, but it might be nice to just the first 200 or so in the future.

Here are some screenshots demonstrating the layout and appearance:
- Loading the data table:
  ![image](https://cloud.githubusercontent.com/assets/7377906/16094256/04c17d4c-3305-11e6-9c30-251480f7d685.png)
- Displaying events:
  ![image](https://cloud.githubusercontent.com/assets/7377906/16094295/2ef9beda-3305-11e6-8d3d-cfe8b43ebf3d.png)
- The header stays at the top!
  ![image](https://cloud.githubusercontent.com/assets/7377906/16094325/527d9412-3305-11e6-8279-c2e57517a242.png)

Also included in this PR is a word-wrap solution for very long links so that they don't shoot off the side of the screen.
