### PR TITLE
Improved load speed on /discover/aggregate by loading shapes asynchronously.

### DIFF
--- a/app/controllers/discover/aggregate.js
+++ b/app/controllers/discover/aggregate.js
@@ -41,12 +41,14 @@ export default Ember.Controller.extend({
     },
     loadShapeDatasets: function(result){
       this.set('shapeDatasets', result);
+      this.set('searchingShapes', false);
     }
   },
 
   modelArrived: Ember.observer('model', function(){
     this.get('timeseriesList').clear();
-    
+    this.set('shapeDatasets', []);
+
     let pointDatasets = this.get('model').pointDatasets;
     let shapeDatasets = this.get('model').shapeDatasets;
     this.set('searchingShapes', true);
@@ -57,7 +59,6 @@ export default Ember.Controller.extend({
     });
     shapeDatasets.then(function(result){
       self.send('loadShapeDatasets', result);
-      self.set('searchingShapes', false);
     });
   }),
 
@@ -74,7 +75,7 @@ export default Ember.Controller.extend({
     let arrivalOrder = 1;
 
     let pointDatasets = this.get('model').pointDatasets._result;
-    let eligible = this.get('model').pointDatasets.length;
+    let eligible = pointDatasets.length;
     let processed = 0;
     let discoverAggregateController = this;
 

--- a/app/controllers/discover/aggregate.js
+++ b/app/controllers/discover/aggregate.js
@@ -63,7 +63,7 @@ export default Ember.Controller.extend({
   /**
    * For each candidate dataset,
    * query the matching timeseries
-   * and push datasets with nonempty detailAggregate onto
+   * and push datasets with nonempty timeseries onto
    * the timeseriesList to display.
    */
   launchTimeseriesQueries() {

--- a/app/controllers/discover/aggregate.js
+++ b/app/controllers/discover/aggregate.js
@@ -6,6 +6,7 @@ export default Ember.Controller.extend({
   discoverController: Ember.inject.controller('discover'),
 
   searchingDatasets: false,
+  searchingShapes: false,
 
   queryParamsClone() {
     return this.get('discoverController').queryParamsClone();
@@ -34,21 +35,35 @@ export default Ember.Controller.extend({
       params['dataset_name'] = name;
       params['data_type'] = fileType;
       this.get('query').rawEvents(params, true);
+    },
+    loadPointDatasets: function(result){
+      this.get('timeseriesList').clear();
+      this.launchTimeseriesQueries();
+    },
+    loadShapeDatasets: function(result){
+      this.set('shapeDatasets', result);
     }
   },
 
-  modelArrived: Ember.observer('model', function() {
-    // Clear the old set of timeseries derived from
-    // the dataset candidates.
-    this.get('timeseriesList').clear();
-    // Launch a new set of timeseries queries from the new candidates.
-    this.launchTimeseriesQueries();
+  modelArrived: Ember.observer('model', function(){
+    let pointDatasets = this.get('model').pointDatasets;
+    let shapeDatasets = this.get('model').shapeDatasets;
+    this.set('searchingShapes', true);
+
+    let self = this;
+    pointDatasets.then(function(result){
+      self.send('loadPointDatasets', result);
+    });
+    shapeDatasets.then(function(result){
+      self.send('loadShapeDatasets', result);
+      self.set('searchingShapes', false);
+    })
   }),
 
   /**
    * For each candidate dataset,
    * query the matching timeseries
-   * and push datasets with nonempty timeseries onto
+   * and push datasets with nonempty detailAggregate onto
    * the timeseriesList to display.
    */
   launchTimeseriesQueries() {
@@ -57,6 +72,7 @@ export default Ember.Controller.extend({
     let timeseriesList = this.get('timeseriesList');
     let arrivalOrder = 1;
 
+    let pointDatasets = this.get('model').pointDatasets._result;
     let eligible = this.get('model').pointDatasets.length;
     let processed = 0;
     let discoverAggregateController = this;
@@ -78,12 +94,12 @@ export default Ember.Controller.extend({
       }
     };
 
-    if(this.get('model').pointDatasets.error) {
-      queryError(this.get('model').pointDatasets.error.message);
+    if(pointDatasets.error) {
+      queryError(pointDatasets.error.message);
       return;
     }
 
-    this.get('model').pointDatasets.forEach((d)=> {
+    pointDatasets.forEach((d)=> {
 
       let params = this.queryParamsClone();
       Ember.assign(params, {dataset_name: d.datasetName});

--- a/app/controllers/discover/aggregate.js
+++ b/app/controllers/discover/aggregate.js
@@ -37,7 +37,6 @@ export default Ember.Controller.extend({
       this.get('query').rawEvents(params, true);
     },
     loadPointDatasets: function(){
-      this.get('timeseriesList').clear();
       this.launchTimeseriesQueries();
     },
     loadShapeDatasets: function(result){
@@ -46,6 +45,8 @@ export default Ember.Controller.extend({
   },
 
   modelArrived: Ember.observer('model', function(){
+    this.get('timeseriesList').clear();
+    
     let pointDatasets = this.get('model').pointDatasets;
     let shapeDatasets = this.get('model').shapeDatasets;
     this.set('searchingShapes', true);

--- a/app/routes/discover/aggregate.js
+++ b/app/routes/discover/aggregate.js
@@ -6,10 +6,10 @@ export default Ember.Route.extend({
   query: Ember.inject.service(),
   model() {
     const params = this.paramsFor('discover');
-    return Ember.RSVP.hash({
+    return {
       pointDatasets: this.get('query').eventCandidates(params),
       shapeDatasets: this.get('query').shapeSubsets(params)
-    });
+    };
   },
   actions: {
     reload: function() {

--- a/app/templates/discover/aggregate.hbs
+++ b/app/templates/discover/aggregate.hbs
@@ -11,13 +11,14 @@
 <div class="row">
   <div class="col-md-12">
       <h3>
-        {{#if shapeDatasets}}<strong>{{shapeDatasets.length}}</strong> {{pluralize 'Shape Dataset' shapeDatasets.length}} Found
-        {{else}}<strong>0</strong> Shape Datasets Found
+        {{#if searchingShapes}}<i>loading shapes...</i>
+        {{else}}<strong>{{shapeDatasets.length}}</strong> {{pluralize 'Shape Dataset' shapeDatasets.length}} Found
         {{/if}}
-        {{#if searchingShapes}}<i>and counting...</i>{{/if}}</h3>
+      </h3>
     {{shape-listing
     displayLink=(action "navigateToShape")
     downloadLink=(action "downloadShape")
     shapeDatasets=shapeDatasets}}
+    {{#if searchingShapes}}{{widget-spin}}{{/if}}
   </div>
 </div>

--- a/app/templates/discover/aggregate.hbs
+++ b/app/templates/discover/aggregate.hbs
@@ -10,10 +10,14 @@
 </div>
 <div class="row">
   <div class="col-md-12">
-    <h3><strong>{{model.shapeDatasets.length}}</strong> {{pluralize 'Shape Dataset' model.shapeDatasets.length}} Found</h3>
+      <h3>
+        {{#if shapeDatasets}}<strong>{{shapeDatasets.length}}</strong> {{pluralize 'Shape Dataset' shapeDatasets.length}} Found
+        {{else}}<strong>0</strong> Shape Datasets Found
+        {{/if}}
+        {{#if searchingShapes}}<i>and counting...</i>{{/if}}</h3>
     {{shape-listing
     displayLink=(action "navigateToShape")
     downloadLink=(action "downloadShape")
-    shapeDatasets=model.shapeDatasets}}
+    shapeDatasets=shapeDatasets}}
   </div>
 </div>


### PR DESCRIPTION
So it appears that much of the load time when querying /discover/aggregate actually comes from loading the shapes before the page loads. This takes 1-2 seconds. In comparison, grabbing the event candidates takes only a couple hundred milliseconds.
![image](https://cloud.githubusercontent.com/assets/7377906/16127179/eee28c52-33c0-11e6-9ea2-4f83fef49136.png)

This PR breaks apart a promise wrapping shapes and events in the /discover/aggregate model, allowing the two to load separately. The result as an almost instantaneous asynchronous load, which makes the loading spinner nearly obsolete. Note that the datasets still take time to load, but the page responds to the user's click immediately.

The gif below compares the current production (first site) to the changes in this PR (second site).
![optimization](https://cloud.githubusercontent.com/assets/7377906/16128867/04391a92-33c8-11e6-9ba6-9f4fd5a50c15.gif)
