### PR TITLE
[split from ux-improvements] Fix and New Feature for the Map Centering Feature.

### DIFF
--- a/app/components/aggregate-query-maker.js
+++ b/app/components/aggregate-query-maker.js
@@ -16,7 +16,6 @@ export default Ember.Component.extend({
         let splits = this.get('center').split(',');
         this.set('centerCoords', [[parseFloat(splits[0]), parseFloat(splits[1])], parseFloat(splits[2])]);
       } else {
-        console.log(this.get('center'));
         this.get('notify').warning(`Unknown city "${this.get('center')}". Try selecting a city from the "Center map on" menu.`);
         this.set('center', 'chicago');
       }
@@ -62,11 +61,10 @@ export default Ember.Component.extend({
     },
     mapMovedByUser(newcenter){
       let self = this;
-      if(!(this.get('center') in this.get('cities') && this.get('centerCoords') === newcenter)) {
-        Ember.run.next(function () {
-          self.set('center', newcenter);
-        });
-      }
+      Ember.run.next(function () {
+        if (self.isDestroyed) { return; } //Workaround to fix testing
+        self.set('center', newcenter);
+      });
     }
   },
 

--- a/app/components/aggregate-query-maker.js
+++ b/app/components/aggregate-query-maker.js
@@ -12,7 +12,11 @@ export default Ember.Component.extend({
         //Translate an initial location to coordinates
         //'centerCoords' is the raw-coordinates form of the human-readable 'center'
         this.set('centerCoords', [this.get(`cities.${this.get('center')}.location`), this.get(`cities.${this.get('center')}.zoom`)]);
+      } else if (this.get('center').split(',').length === 3) {
+        let splits = this.get('center').split(',');
+        this.set('centerCoords', [[parseFloat(splits[0]), parseFloat(splits[1])], parseFloat(splits[2])]);
       } else {
+        console.log(this.get('center'));
         this.get('notify').warning(`Unknown city "${this.get('center')}". Try selecting a city from the "Center map on" menu.`);
         this.set('center', 'chicago');
       }
@@ -56,6 +60,14 @@ export default Ember.Component.extend({
     dismissIntro(){
       $("#collapse-intro").collapse("hide");
     },
+    mapMovedByUser(newcenter){
+      let self = this;
+      if(!(this.get('center') in this.get('cities') && this.get('centerCoords') === newcenter)) {
+        Ember.run.next(function () {
+          self.set('center', newcenter);
+        });
+      }
+    }
   },
 
 });

--- a/app/components/leaflet-map.js
+++ b/app/components/leaflet-map.js
@@ -29,6 +29,11 @@ export default Ember.Component.extend({
       this.addTiles();
       this.drawElements();
       this.createLegend();
+
+      let self = this;
+      this.map.on('moveend', function(){ //Setup listener that signals the parent component when the map changes.
+        self.updateCenter(self);
+      });
     });
   },
 
@@ -213,5 +218,13 @@ export default Ember.Component.extend({
   changedCenter: Ember.observer('center', function() {
     this.get('map').setView(new L.LatLng(...this.get('center')[0]), this.get('center')[1]);
   }),
+
+  //Scope here seems a bit different, eh?
+  //It's because it's bound to a map event ('moveend') way up in didInsertElement
+  updateCenter(self) {
+    if(!(self.map.getCenter().lat === this.get('center')[0][0] && self.map.getCenter().lng === this.get('center')[0][1] && self.map.getZoom() === this.get('center')[1])) {
+      self.sendAction('mapMovedByUser', [[self.map.getCenter().lat, self.map.getCenter().lng], self.map.getZoom()]);
+    }
+  },
 
 });

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -37,6 +37,7 @@ export default Ember.Controller.extend({
   //IDs for cities, their locations and zoom.
 
   cities: {
+    "00default": {label: "Select a city to teleport to it.", location: [41.795509, -87.581916], zoom: 10},
     "chicago": {label: "Chicago", location: [41.795509, -87.581916], zoom: 10},
     "newyork": {label: "New York", location:[40.7268362,-74.0017699], zoom: 10},
     "seattle": {label: "Seattle", location:[47.6076397,-122.3258644], zoom: 11},

--- a/app/templates/components/aggregate-query-maker.hbs
+++ b/app/templates/components/aggregate-query-maker.hbs
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="col-md-7 half-height">
-      {{leaflet-map center=centerCoords geoJSON=geoJSON isDrawable=true zoom=zoom}}
+      {{leaflet-map center=centerCoords mapMovedByUser=(action 'mapMovedByUser') geoJSON=geoJSON isDrawable=true zoom=zoom}}
     </div>
   </div>
 

--- a/tests/acceptance/error-handling-test.js
+++ b/tests/acceptance/error-handling-test.js
@@ -32,7 +32,9 @@ test('Using an invalid agg option will return to index and issue an error.', fun
     visit('/discover?agg=ksdfasdkh&location_geom__within=' + geoJSON);
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
     });
   });
 });
@@ -44,7 +46,9 @@ test('Attempting to query with startDate after endDate returns to index and issu
     visit('/discover?obs_date__ge=2016-06-18&obs_date__le=2016-06-12&location_geom__within=' + geoJSON);
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
     });
   });
 });
@@ -57,14 +61,18 @@ test('Attempting to query with invalid startDate and endDate returns to index an
     visit('/discover?obs_date__ge=20asdkgasdj8&obs_date__le=2016-06-12&location_geom__within=' + geoJSON);
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
-      visit('/discover/aggregate?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
       andThen(function () {
-        assert.equal(currentRouteName(), 'discover.index', 'The page returns to index. (obs_date__le)');
-        visit('/discover?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+        visit('/discover/aggregate?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
         andThen(function () {
-          $('#submit-query').click();
-          assert.notEqual($('.message').text(), "", "The page issued an error.");
+          assert.equal(currentRouteName(), 'discover.index', 'The page returns to index. (obs_date__le)');
+          visit('/discover?obs_date__ge=2016-06-18&obs_date__le=201asgasd12&location_geom__within=' + geoJSON);
+          andThen(function () {
+            $('#submit-query').click();
+            andThen(function () {
+              assert.notEqual($('.message').text(), "", "The page issued an error.");
+            });
+          });
         });
       });
     });
@@ -79,7 +87,9 @@ test('Attempting to query with invalid JSON returns to index and issues an error
     visit('/discover?location_geom__within=%7B%22type%22%3A%22Feature%22%3A%7B%7D%2C%22geometry%22%3A%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-87.80672550201416%2C41.74262728637672%5D%2C%5B-87.80672550201416%2C41.97582726102573%5D%2C%5B-87.45653629302979%2C41.97582726102573%5D%2C%5B-87.45653629302979%2C41.74262728637672%5D%2C%5B-87.80672550201416%2C41.74262728637672%5D%5D%5D%7D%7D');
     andThen(function () {
       $('#submit-query').click();
-      assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
     });
   });
 });
@@ -89,8 +99,12 @@ test('Attempting to query without a geoJSON returns to index and issues an error
   andThen(function () {
     assert.equal(currentRouteName(), 'discover.index', 'The page returns to index.');
     visit('/discover');
+    andThen(function(){
     $('#submit-query').click();
-    assert.notEqual($('.message').text(), "", "The page issued an error.");
+      andThen(function () {
+        assert.notEqual($('.message').text(), "", "The page issued an error.");
+      });
+    });
   });
 });
 

--- a/tests/acceptance/user-query-test.js
+++ b/tests/acceptance/user-query-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import {test} from 'qunit';
 import moduleForAcceptance from 'plenario-explorer/tests/helpers/module-for-acceptance';
 import testData from 'plenario-explorer/mirage/test-data';
@@ -55,12 +56,16 @@ test('User can reset a query.', function (assert) {
   visit('/discover/aggregate?location_geom__within=' + geoJSON + '&obs_date__ge=2010-06-10&obs_date__le=2017-07-02');
   andThen(function () {
     assert.equal($('#point-aggregate-listing').is('div'), true);
-    click('#reset-query');
-    andThen(function () {
-      assert.equal(currentURL(), '/discover', "Resetting the route returns to /discover.");
-      assert.equal($('#point-aggregate-listing').is('div'), false, "Resetting the route succeeded; point aggregate listing is no longer present.");
-      assert.equal($('#point-index-listing').is('div'), true, "Resetting the route succeeded; point index listing is now present.");
-    });
+    return Ember.run.later(function(){ //Wait for everything to stop moving
+      click('#reset-query');
+      andThen(function () {
+        return Ember.run.later(function(){
+          assert.equal(currentURL(), '/discover', "Resetting the route returns to /discover.");
+          assert.equal($('#point-aggregate-listing').is('div'), false, "Resetting the route succeeded; point aggregate listing is no longer present.");
+          assert.equal($('#point-index-listing').is('div'), true, "Resetting the route succeeded; point index listing is now present.");
+        });
+      });
+    }, 10);
   });
 });
 
@@ -89,6 +94,14 @@ test('Changing the map center selection changes the actual map.', function (asse
         });
       });
     });
+  });
+});
+
+
+test('User can directly specify a map center coordinates via the URL.', function(assert){
+  visit('/discover?center=51.89426503878691,1.4826178550720215,15');
+  andThen(function(){
+    assert.notEqual($('#map').find('img[src$="/15/16518/10839.png"]').length, 0, "Map uses coordinates to center on Sealand.");  //Sealand map tile
   });
 });
 


### PR DESCRIPTION
This PR fixes a small oddity in the map centering feature in the aggregate-query-maker component where the user had to select a different city and then the desired city if the user had already center at the desired city (and had since panned a bit and wanted to re-center).

This PR also introduces a feature which ties the map center--even after the user has panned or zoomed away from a city--to the center query parameter. This means that the URL updates with new coordinates as the user pans/zooms the map, and the user can save and share the URL later to access the query page with the same map center.

A gif demonstrating
1. Changing coordinates after panning;
2. Recentering on the city; and
3. Ability to copy the link to visit the same map center again.

![map](https://cloud.githubusercontent.com/assets/7377906/16247645/50f3c77c-37d0-11e6-9f8c-764e19474090.gif)

This PR contains changes cherry-picked from [the old ux-improvents PR](https://github.com/UrbanCCD-UChicago/plenario-explorer/pull/5), which has since been closed.
